### PR TITLE
Fix Azure GPT-5 deployment support

### DIFF
--- a/src/modules/llms/server/openai/openai.router.ts
+++ b/src/modules/llms/server/openai/openai.router.ts
@@ -536,10 +536,14 @@ export function openAIAccess(access: OpenAIAccessSchema, modelRefId: string | nu
         throw new Error('Missing Azure API Key or Host. Add it on the UI (Models Setup) or server side (your deployment).');
 
       let url = azureHost;
-      if (apiPath.startsWith('/v1/')) {
+      if (apiPath === '/v1/responses' && modelRefId?.toLowerCase().includes('gpt-5')) {
+        url += `/openai/v1/responses?api-version=preview`;
+      } else if (apiPath.startsWith('/v1/')) {
         if (!modelRefId)
           throw new Error('Azure OpenAI API needs a deployment id');
-        url += `/openai/deployments/${modelRefId}/${apiPath.replace('/v1/', '')}?api-version=2025-02-01-preview`;
+        // Non-Responses GPT-5 family still uses the 2025-01-01-preview API version
+        const apiVersion = modelRefId.toLowerCase().includes('gpt-5') ? '2025-01-01-preview' : '2025-02-01-preview';
+        url += `/openai/deployments/${modelRefId}/${apiPath.replace('/v1/', '')}?api-version=${apiVersion}`;
       } else if (apiPath.startsWith('/openai/deployments'))
         url += apiPath;
       else


### PR DESCRIPTION
## Summary
- Route Azure GPT-5 deployments through the new /openai/v1/responses preview endpoint
- Remove Azure-specific exclusion so GPT-5 models leverage the Responses API like other models

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6896433078bc8326a2709ef30d9cee0f