### PR TITLE
Add Azure OpenAI image generation support

### DIFF
--- a/src/apps/draw/create/DrawProviderConfigure.tsx
+++ b/src/apps/draw/create/DrawProviderConfigure.tsx
@@ -29,7 +29,9 @@ export function DrawProviderConfigure(props: {
 
   const { ProviderConfig } = React.useMemo(() => {
     const provider = providers.find(provider => provider.providerId === activeProviderId);
-    const ProviderConfig: React.FC | null = provider?.vendor === 'openai' ? DallESettings : null;
+    const ProviderConfig: React.FC | null = (provider?.vendor === 'openai' || provider?.vendor === 'azure')
+      ? DallESettings
+      : null;
     return {
       ProviderConfig,
     };

--- a/src/apps/draw/create/DrawProviderSelector.tsx
+++ b/src/apps/draw/create/DrawProviderSelector.tsx
@@ -7,6 +7,7 @@ import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 
 import type { TextToImageProvider } from '~/common/components/useCapabilities';
 import { OpenAIIcon } from '~/common/components/icons/vendors/OpenAIIcon';
+import { AzureIcon } from '~/common/components/icons/vendors/AzureIcon';
 import { hideOnMobile } from '~/common/app.theme';
 import { optimaSelectSlotProps } from '~/common/layout/optima/bar/OptimaBarDropdown';
 
@@ -27,7 +28,11 @@ export function DrawProviderSelector(props: {
         label: provider.label + (provider.painter !== provider.label ? ` ${provider.painter}` : ''),
         value: provider.providerId,
         configured: provider.configured,
-        Icon: provider.vendor === 'openai' ? OpenAIIcon : FormatPaintTwoToneIcon,
+        Icon: provider.vendor === 'openai'
+          ? OpenAIIcon
+          : provider.vendor === 'azure'
+            ? AzureIcon
+            : FormatPaintTwoToneIcon,
       });
     });
     return options;

--- a/src/common/components/useCapabilities.ts
+++ b/src/common/components/useCapabilities.ts
@@ -48,6 +48,7 @@ export interface TextToImageProvider {
 type TextToImageVendor =
   | 'gemini'
   | 'localai'
+  | 'azure'
   | 'openai'
   | 'xai'
   ;


### PR DESCRIPTION
## Summary
- route Azure OpenAI requests for `/v1/images/*` endpoints to the appropriate Azure paths and add JSON accept headers
- expose Azure model services as OpenAI-compatible text-to-image providers, including provider prioritization and edit availability logic
- update the draw provider UI to surface Azure services with the correct icon and GPT Image configuration panel

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ee96f15df88326bf54a638795bc7bc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added Azure OpenAI as a supported provider for text-to-image.
  - Azure now appears in the provider list with an appropriate icon and description.
  - DALL·E settings are available when selecting Azure, matching OpenAI behavior.
  - Image generation routes support Azure deployments and API versions.
  - Editing of image prompts is enabled when an Azure provider is active.
- Improvements
  - Unified handling of OpenAI-compatible providers, aligning Azure with OpenAI for image workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->